### PR TITLE
Ignore SIGTERM when a job is running

### DIFF
--- a/class-command.php
+++ b/class-command.php
@@ -22,6 +22,9 @@ class Command extends WP_CLI_Command {
 			WP_CLI::error( 'Invalid job ID' );
 		}
 
+		// Handle SIGTERM calls as we don't want to kill a running job
+		pcntl_signal( SIGTERM, SIG_IGN );
+
 		/**
 		 * Fires scheduled events.
 		 *


### PR DESCRIPTION
If the daemon for Cavalcade is shutdown, SIGTERM get's sent to all
running child processes, which we want to ignore as we don't want to
stop the job part way through. As the process will only be doing the
single job and then quitting, we can just ignore the signal.