### PR TITLE
Use object cache

### DIFF
--- a/class-job.php
+++ b/class-job.php
@@ -51,7 +51,7 @@ class Job {
 			$data['interval'] = $this->interval;
 		}
 
-		wp_cache_delete( "jobs:{$this->site}" );
+		wp_cache_delete( "jobs:{$this->site}", 'cavalcade-jobs' );
 
 		if ( $this->is_created() ) {
 			$where = array(
@@ -83,7 +83,7 @@ class Job {
 		);
 		$result = $wpdb->delete( $this->get_table(), $where, $this->row_format( $where ) );
 
-		wp_cache_delete( "jobs:{$this->site}" );
+		wp_cache_delete( "jobs:{$this->site}", 'cavalcade-jobs' );
 
 		return (bool) $result;
 

--- a/class-job.php
+++ b/class-job.php
@@ -195,6 +195,7 @@ class Job {
             if ( ! $include_completed && ! $include_failed ) {
                 wp_cache_set( "jobs:{$site}", $results, 'cavalcade' );
             }
+
 		}
 
 		if ( empty( $results ) ) {

--- a/class-job.php
+++ b/class-job.php
@@ -51,6 +51,8 @@ class Job {
 			$data['interval'] = $this->interval;
 		}
 
+		wp_cache_delete( "jobs:{$this->site}" );
+
 		if ( $this->is_created() ) {
 			$where = array(
 				'id' => $this->id,
@@ -80,6 +82,9 @@ class Job {
 			'id' => $this->id,
 		);
 		$result = $wpdb->delete( $this->get_table(), $where, $this->row_format( $where ) );
+
+		wp_cache_delete( "jobs:{$this->site}" );
+
 		return (bool) $result;
 
 	}
@@ -166,21 +171,32 @@ class Job {
 			return new WP_Error( 'cavalcade.job.invalid_site_id' );
 		}
 
-		$statuses = array( 'waiting', 'running' );
-		if ( $include_completed ) {
-			$statuses[] = 'completed';
-		}
-		if ( $include_failed ) {
-			$statuses[] = 'failed';
+        if ( ! $include_completed && ! $include_failed ) {
+            $results = wp_cache_get( "jobs:{$site}", 'cavalcade' );
+        }
+
+		if ( isset( $results ) && ! $results ) {
+			$statuses = array( 'waiting', 'running' );
+			if ( $include_completed ) {
+				$statuses[] = 'completed';
+			}
+			if ( $include_failed ) {
+				$statuses[] = 'failed';
+			}
+
+			// Find all scheduled events for this site
+			$table = static::get_table();
+
+			$sql = "SELECT * FROM `{$table}` WHERE site = %d";
+			$sql .= " AND status IN(" . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ")";
+			$query = $wpdb->prepare( $sql, array_merge( array( $site ), $statuses ) );
+			$results = $wpdb->get_results( $query );
+
+            if ( ! $include_completed && ! $include_failed ) {
+                wp_cache_set( "jobs:{$site}", $results, 'cavalcade' );
+            }
 		}
 
-		// Find all scheduled events for this site
-		$table = static::get_table();
-		
-		$sql = "SELECT * FROM `{$table}` WHERE site = %d";
-		$sql .= " AND status IN(" . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ")";
-		$query = $wpdb->prepare( $sql, array_merge( array( $site ), $statuses ) );
-		$results = $wpdb->get_results( $query );
 		if ( empty( $results ) ) {
 			return array();
 		}

--- a/class-job.php
+++ b/class-job.php
@@ -171,9 +171,9 @@ class Job {
 			return new WP_Error( 'cavalcade.job.invalid_site_id' );
 		}
 
-        if ( ! $include_completed && ! $include_failed ) {
-            $results = wp_cache_get( "jobs:{$site}", 'cavalcade' );
-        }
+		if ( ! $include_completed && ! $include_failed ) {
+			$results = wp_cache_get( "jobs:{$site}", 'cavalcade' );
+		}
 
 		if ( isset( $results ) && ! $results ) {
 			$statuses = array( 'waiting', 'running' );
@@ -192,9 +192,9 @@ class Job {
 			$query = $wpdb->prepare( $sql, array_merge( array( $site ), $statuses ) );
 			$results = $wpdb->get_results( $query );
 
-            if ( ! $include_completed && ! $include_failed ) {
-                wp_cache_set( "jobs:{$site}", $results, 'cavalcade' );
-            }
+			if ( ! $include_completed && ! $include_failed ) {
+				wp_cache_set( "jobs:{$site}", $results, 'cavalcade' );
+			}
 
 		}
 

--- a/class-job.php
+++ b/class-job.php
@@ -51,7 +51,7 @@ class Job {
 			$data['interval'] = $this->interval;
 		}
 
-		wp_cache_delete( "jobs:{$this->site}", 'cavalcade-jobs' );
+		wp_cache_delete( 'jobs', 'cavalcade-jobs' );
 
 		if ( $this->is_created() ) {
 			$where = array(
@@ -83,7 +83,7 @@ class Job {
 		);
 		$result = $wpdb->delete( $this->get_table(), $where, $this->row_format( $where ) );
 
-		wp_cache_delete( "jobs:{$this->site}", 'cavalcade-jobs' );
+		wp_cache_delete( 'jobs', 'cavalcade-jobs' );
 
 		return (bool) $result;
 
@@ -193,7 +193,7 @@ class Job {
 			$results = $wpdb->get_results( $query );
 
 			if ( ! $include_completed && ! $include_failed ) {
-				wp_cache_set( "jobs:{$site}", $results, 'cavalcade' );
+				wp_cache_set( 'jobs', $results, 'cavalcade' );
 			}
 
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -20,6 +20,7 @@ require __DIR__ . '/connector.php';
  */
 function bootstrap() {
 	wp_cache_add_global_groups( array( 'cavalcade' ) );
+	wp_cache_add_non_persistent_groups( array( 'cavalcade-jobs' ) );
 
 	if ( ! is_installed() ) {
 		create_tables();


### PR DESCRIPTION
We've noticed up to 40 duplicate database queries using Cavalcade, which is adding around 100-150ms to each page load for us, even with `DISABLE_WP_CRON` set.

![screen shot 2016-11-06 at 1 09 10 pm](https://cloud.githubusercontent.com/assets/665029/20041728/4a71c598-a422-11e6-9c21-2817bf3b3004.png)

This PR adds `wp_cache_get()` to `HM\Cavalcade\Plugin\Job::get_by_site()` and deletes the cache when saving/deleting jobs.

I also went ahead and made the coding style more uniform.