### PR TITLE
Don't include failed jobs in the WordPress cron array. 

### DIFF
--- a/class-job.php
+++ b/class-job.php
@@ -176,8 +176,10 @@ class Job {
 
 		// Find all scheduled events for this site
 		$table = static::get_table();
-		$sql = "SELECT * FROM `{$table}` WHERE site = %d AND status IN('" . implode( "','", $statuses ) . "')";
-		$query = $wpdb->prepare( $sql, $site );
+		
+		$sql = "SELECT * FROM `{$table}` WHERE site = %d";
+		$sql .= " AND status IN(" . implode( ',', array_fill( 0, count( $statuses ), '%s' ) ) . ")";
+		$query = $wpdb->prepare( $sql, array_merge( array( $site ), $statuses ) );
 		$results = $wpdb->get_results( $query );
 		if ( empty( $results ) ) {
 			return array();


### PR DESCRIPTION
Don't include failed jobs in the WordPress cron array. This allows WordPress to re-queue a recurring cron task after it's failed - See #23

This has potential back-compat issues for anything calling Job::get_by_site() and expecting failed jobs in the resulting data.
The parameter could be switched to default to true, with the WP compat shim explicitly passing false if that's a concern.