### PR TITLE
Remove site id from cache key missed in #26

### DIFF
--- a/class-job.php
+++ b/class-job.php
@@ -172,7 +172,7 @@ class Job {
 		}
 
 		if ( ! $include_completed && ! $include_failed ) {
-			$results = wp_cache_get( "jobs:{$site}", 'cavalcade' );
+			$results = wp_cache_get( 'jobs', 'cavalcade' );
 		}
 
 		if ( isset( $results ) && ! $results ) {

--- a/class-job.php
+++ b/class-job.php
@@ -172,7 +172,7 @@ class Job {
 		}
 
 		if ( ! $include_completed && ! $include_failed ) {
-			$results = wp_cache_get( 'jobs', 'cavalcade' );
+			$results = wp_cache_get( 'jobs', 'cavalcade-jobs' );
 		}
 
 		if ( isset( $results ) && ! $results ) {
@@ -193,7 +193,7 @@ class Job {
 			$results = $wpdb->get_results( $query );
 
 			if ( ! $include_completed && ! $include_failed ) {
-				wp_cache_set( 'jobs', $results, 'cavalcade' );
+				wp_cache_set( 'jobs', $results, 'cavalcade-jobs' );
 			}
 
 		}

--- a/plugin.php
+++ b/plugin.php
@@ -19,12 +19,24 @@ require __DIR__ . '/connector.php';
  * Bootstrap the plugin and get it started!
  */
 function bootstrap() {
-	wp_cache_add_global_groups( array( 'cavalcade' ) );
-	wp_cache_add_non_persistent_groups( array( 'cavalcade-jobs' ) );
+	register_cache_groups();
 
 	if ( ! is_installed() ) {
 		create_tables();
 	}
+}
+
+/**
+ * Register the cache groups
+ */
+function register_cache_groups() {
+	wp_cache_add_global_groups( array( 'cavalcade' ) );
+	wp_cache_add_non_persistent_groups( array( 'cavalcade-jobs' ) );
+}
+
+// Register cache groups as early as possible, as some plugins may use cron functions before plugins_loaded
+if ( function_exists( 'wp_cache_add_global_groups' ) ) {
+	register_cache_groups();
 }
 
 /**


### PR DESCRIPTION
When the job cache was added in #26 the site id was left in the getter, which results in the cache not being used.