### PR TITLE
Add mu-plugin symlink instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ high traffic, large installs. Don't install it on every site just for fun.
 Clone or submodule this repository into your `mu-plugins` directory, and load it
 as an MU plugin.
 
+```
+cd /path/to/your/mu-plugins
+ln -s cavalcade/plugin.php cavalcade.php
+```
+
 To start using it in your code, don't change anything. Simply use the normal
 wp-cron functions, such as `wp_schedule_event`, `wp_schedule_single_event` and
 `wp_next_scheduled`. Cavalcade integrates seamlessly into these, and the first

--- a/README.md
+++ b/README.md
@@ -116,11 +116,12 @@ high traffic, large installs. Don't install it on every site just for fun.
 ### WordPress Plugin
 
 Clone or submodule this repository into your `mu-plugins` directory, and load it
-as an MU plugin.
+as an MU plugin. For example, create `mu-plugins/cavalcade.php` with the
+following code:
 
 ```
-cd /path/to/your/mu-plugins
-ln -s cavalcade/plugin.php cavalcade.php
+<?php
+require_once __DIR__ . '/cavalcade/plugin.php';
 ```
 
 To start using it in your code, don't change anything. Simply use the normal


### PR DESCRIPTION
This saves people from having to look through the `*.php` files to figure out which one is the bootstrap file. Most will probably guess that it's `plugin.php`, but it doesn't hurt to remove any doubt.