### PR TITLE
Use global namespace for WP_CLI

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -30,7 +30,7 @@ function register_cli_commands() {
 	}
 
 	require __DIR__ . '/class-command.php';
-	WP_CLI::add_command( 'cavalcade', __NAMESPACE__ . '\\Command' );
+	\WP_CLI::add_command( 'cavalcade', __NAMESPACE__ . '\\Command' );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -2,6 +2,8 @@
 
 namespace HM\Cavalcade\Plugin;
 
+use WP_CLI;
+
 /**
  * Bootstrap the plugin and get it started!
  */
@@ -30,7 +32,7 @@ function register_cli_commands() {
 	}
 
 	require __DIR__ . '/class-command.php';
-	\WP_CLI::add_command( 'cavalcade', __NAMESPACE__ . '\\Command' );
+	WP_CLI::add_command( 'cavalcade', __NAMESPACE__ . '\\Command' );
 }
 
 /**


### PR DESCRIPTION
Seems like running `wp cavalcade` causes an error due to using `HM\Cavalcade\Plugin\WP_CLI`.