### PR TITLE
Add WordPress plugin comment header

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,12 @@
 <?php
 /**
- * Cavalcade!
+ * Plugin Name: Cavalcade
+ * Plugin URI: https://github.com/humanmade/Cavalcade
+ * Description: Scalable job system, designed as a drop-in replacement for wp_cron
+ * Version: 0.1
+ * Author: Human Made
+ * Author URI: https://hmn.md/
+ * License: GPLv2 or later
  */
 
 namespace HM\Cavalcade\Plugin;

--- a/plugin.php
+++ b/plugin.php
@@ -2,8 +2,7 @@
 /**
  * Plugin Name: Cavalcade
  * Plugin URI: https://github.com/humanmade/Cavalcade
- * Description: Scalable job system, designed as a drop-in replacement for wp_cron
- * Version: 0.1
+ * Description: A better wp-cron. Horizontally scalable, works perfectly with multisite.
  * Author: Human Made
  * Author URI: https://hmn.md/
  * License: GPLv2 or later


### PR DESCRIPTION
The readme says that in order to use this plugin I need to add extra `mu-plugins/cavalcade.php`.

I usually have so many mu-plugins that this practice gets really hard to maintain and normally I don't add extra includes for each mu-plugin but instead I use [bedrock-autoloader.php](https://github.com/roots/bedrock/blob/master/web/app/mu-plugins/bedrock-autoloader.php).

This can load all plugins from subfolders inside mu-plugins folder. But the problem here is that it doesn't work  if the plugin in subfolder doesn't have correct comment headers in the start of the file.

This pull request fixes this problem and allows installation into subfolder without extra steps.

More info: https://roots.io/bedrock/docs/mu-plugins-autoloader/