### PR TITLE
Add license to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
 	"description": "A better wp-cron. Horizontally scalable, works perfectly with multisite.",
 	"homepage": "https://github.com/humanmade/Cavalcade",
 	"type": "wordpress-muplugin",
+	"license": "GPL-2.0+",
 	"authors": [
 		{
 			"name": "Human Made",


### PR DESCRIPTION
I have git-hook which checks that `composer.json` files are valid. Adding license fixes composer validate command:
```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
No license specified, it is recommended to do so. For closed-source software you may use "proprietary" as license.
```