### PR TITLE
Update PDO to requirements mentioned for Cavalcade-Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,10 @@ nohup bin/cavalcade > /var/log/cavalcade.log &
 (Cavalcade outputs all relevant logging information to stdout, and only sends
 meta-information such as shutdown notices to stderr.)
 
-Note: The runner has two additional requirements:
+Note: The runner has three additional requirements:
 
 * **pcntl** - The [Process Control PHP extension](http://php.net/pcntl) must be installed. Cavalcade Runner uses this to spawn worker processes and keep monitor them.
+* **pdo** - The [PHP Data Objects (PDO)](http://php.net/pdo) must be installed. Cavalcade Runner uses this to access WordPress database.
 * **wp-cli** - wp-cli must be installed on your server and available in the PATH. Cavalcade Runner internally calls `wp cavalcade run <id>` to run the jobs.
 
 The runner is an independent piece of Cavalcade, so writing your own runner is possible if you have alternative requirements.


### PR DESCRIPTION
Cavalcade-Runner needs actually: `ext-pdo` and `ext-pdo_mysql` in order to work. These are usually installed but those were originally missing from my minimal environment.