### PR TITLE
Include interval in realkey to allow for changed schedules.

### DIFF
--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -94,10 +94,6 @@ function update_cron_array( $value, $old_value ) {
 						$hook = 'wp_batch_split_terms';
 					}
 
-					if ( isset( $item['interval'] ) ) {
-						$key .= (string) $item['interval'];
-					}
-
 					$real_key = sha1( $timestamp . $hook . $key );
 					$new[ $real_key ] = [
 						'timestamp' => $timestamp,

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -90,6 +90,10 @@ function update_cron_array( $value, $old_value ) {
 						$hook = 'wp_batch_split_terms';
 					}
 
+					if ( isset( $item['interval'] ) ) {
+						$key .= (string) $item['interval'];
+					}
+
 					$real_key = sha1( $timestamp . $hook . $key );
 					$new[ $real_key ] = [
 						'timestamp' => $timestamp,

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -94,7 +94,13 @@ function update_cron_array( $value, $old_value ) {
 						$hook = 'wp_batch_split_terms';
 					}
 
-					$real_key = sha1( $timestamp . $hook . $key );
+					$real_key = $timestamp . $hook . $key;
+
+					if ( isset( $item['interval'] ) ) {
+						$real_key .= (string) $item['interval'];
+					}
+
+					$real_key = sha1( $real_key );
 					$new[ $real_key ] = [
 						'timestamp' => $timestamp,
 						'hook' => $hook,

--- a/tests/tests/class-rescheduling.php
+++ b/tests/tests/class-rescheduling.php
@@ -23,13 +23,14 @@ class Tests_Core extends WP_UnitTestCase {
 
 	function test_recheduling() {
 		$timestamp = time() + HOUR_IN_SECONDS;
+		$key = md5( serialize( [] ) );
 
 		wp_schedule_event( $timestamp, 'hourly', 'cavalcade_repeat' );
 		wp_schedule_event( $timestamp, 'daily', 'cavalcade_repeat' );
 
 		$next_scheduled = _get_cron_array()[ wp_next_scheduled( 'cavalcade_repeat' ) ];
 		$expected = wp_get_schedules()['daily']['interval'];
-		$actual = $next_scheduled['interval'];
+		$actual = $next_scheduled['cavalcade_repeat'][ $key ]['interval'];
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/tests/class-rescheduling.php
+++ b/tests/tests/class-rescheduling.php
@@ -1,0 +1,36 @@
+<?php
+namespace HM\Cavalcade\Tests;
+
+use WP_UnitTestCase;
+
+/**
+ * Test rescheduling an event is successful.
+ *
+ * @ticket 64
+ */
+class Tests_Core extends WP_UnitTestCase {
+	function setUp() {
+		parent::setUp();
+		// make sure the schedule is clear
+		_set_cron_array(array());
+	}
+
+	function tearDown() {
+		// make sure the schedule is clear
+		_set_cron_array(array());
+		parent::tearDown();
+	}
+
+	function test_recheduling() {
+		$timestamp = time() + HOUR_IN_SECONDS;
+
+		wp_schedule_event( $timestamp, 'hourly', 'cavalcade_repeat' );
+		wp_schedule_event( $timestamp, 'daily', 'cavalcade_repeat' );
+
+		$next_scheduled = _get_cron_array()[ wp_next_scheduled( 'cavalcade_repeat' ) ];
+		$expected = wp_get_schedules()['daily']['interval'];
+		$actual = $next_scheduled['interval'];
+
+		$this->assertEquals( $expected, $actual );
+	}
+}


### PR DESCRIPTION
Includes the interval when generating keys for comparing old and new values of the cron array so events with a changed recurrence are re-saved.

In the database, this deletes the old job and then saves the event with a new ID. I considered using `array_intersect_key()` and looping through the result to see if any intervals had changed but decided this would probably be a bigger perf hit on large tables than the extra database write. Did I test this theory? No.

See #64 