### PR TITLE
Document how to manually manage jobs.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -47,3 +47,6 @@ If you're using Upstart (Ubuntu 12.04, 14.04) or systemd (Ubuntu 16.04+), we rec
 
 Note that while the Runner does not require system-level user access (such as a root account), we don’t recommend using it on systems you don’t control (such as shared hosting).
 
+### Usage
+
+You can manually manage jobs via the `wp cavalcade` command, run `wp help cavalcade` for full documentation.


### PR DESCRIPTION
The `wp cavalcade` command is an essential part of managing a Cavalcade site, but previously the only mention of it was buried in the installation requirements.

It'd been a year or two since I'd needed to use it, and I'd forgotten that the commands were implemented under WP-CLI rather than the runner daemon (which makes sense in hindsight), so it took me 10 minutes of looking through code and documentation to figure out how to list/run jobs again.

Giving it a dedicated section in the Install documentation makes it much more discoverable.