### PR TITLE
Improve Travis CI test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ env:
     WP_VERSION: trunk
   - WP_MULTISITE: 1
     WP_VERSION: trunk
+matrix:
+  exclude:
+    - env: WP_VERSION=trunk
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: php
-matrix:
-  include:
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+env:
+  - WP_MULTISITE: 0
+  - WP_MULTISITE: 1
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: php
-php:
-  - '7.1'
+matrix:
+  include:
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ php:
 env:
   - WP_MULTISITE: 0
   - WP_MULTISITE: 1
+  - WP_MULTISITE: 0
+    WP_VERSION: trunk
+  - WP_MULTISITE: 1
+    WP_VERSION: trunk
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ php:
 env:
   - WP_MULTISITE: 0
   - WP_MULTISITE: 1
-  - WP_MULTISITE: 0
-    WP_VERSION: trunk
-  - WP_MULTISITE: 1
-    WP_VERSION: trunk
 matrix:
-  exclude:
-    - env: WP_VERSION=trunk
+  include:
+    - php: 7.3
+      env: WP_VERSION=trunk WP_MULTISITE=0
+    - php: 7.3
+      env: WP_VERSION=trunk WP_MULTISITE=1
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
-  - phpunit
+  - vendor/bin/phpunit
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ php:
   - 7.2
   - 7.3
 env:
-  - WP_MULTISITE: 0
-  - WP_MULTISITE: 1
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
 matrix:
   include:
     - php: 7.3
@@ -14,7 +14,7 @@ matrix:
       env: WP_VERSION=trunk WP_MULTISITE=1
 install:
   - composer install
-  - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
+  - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
 script:
   - vendor/bin/phpunit
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {
-		"humanmade/coding-standards": "dev-master"
+		"humanmade/coding-standards": "dev-master",
+		"phpunit/phpunit": "^7.5"
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,11 @@ if ( false !== getenv( 'WP_DEVELOP_DIR' ) ) {
 	$test_root = '/tmp/wordpress-tests-lib';
 }
 
+if ( '1' === getenv( 'WP_MULTISITE' ) ) {
+	define( 'MULTISITE', true );
+	define( 'WP_TESTS_MULTISITE', true );
+}
+
 require $test_root . '/includes/functions.php';
 
 tests_add_filter( 'muplugins_loaded', function () {


### PR DESCRIPTION
This expands the test matrix to include:

* Supported versions of PHP
* Multisite and single site installs
* tests WP trunk along with the latest version (only on PHP 7.3 rather than all version of PHP)

It does take a little longer to build so you may wish to cut it back a bit.