### PR TITLE
Ensure blog is installed before creating tables.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -136,7 +136,7 @@ function maybe_populate_site_option() {
 
 	$cavalcade_db_version = get_option( 'cavalcade_db_version' );
 
-	$set_site_meta = function( $site_meta ) use ( $cavalcade_db_version ) {
+	$set_site_meta = function ( $site_meta ) use ( $cavalcade_db_version ) {
 		$site_meta['cavalcade_db_version'] = $cavalcade_db_version;
 		return $site_meta;
 	};

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -11,6 +11,7 @@ function bootstrap() {
 	register_cache_groups();
 
 	if ( ! is_installed() && ! create_tables() ) {
+		add_action( 'wp_install', __NAMESPACE__ . '\\bootstrap' );
 		return;
 	}
 
@@ -105,6 +106,17 @@ function create_tables() {
 
 	wp_cache_set( 'installed', true, 'cavalcade' );
 	update_site_option( 'cavalcade_db_version', DATABASE_VERSION );
+	/*
+	 * Ensure site meta is populated when running the WP CLI script to
+	 * install a network. Using the CLI, WP installs a single site with
+	 * wp_install() and then upgrades it to a multiste install immediately.
+	 *
+	 * Note: This does not work for multisite manual installs.
+	 */
+	add_filter( 'populate_network_meta', function( $site_meta ) {
+		$site_meta['cavalcade_db_version'] = DATABASE_VERSION;
+		return $site_meta;
+	} );
 	return true;
 }
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -125,11 +125,11 @@ function create_tables() {
  * Populate the Cavalcade db version when upgrading to multisite.
  *
  * This ensures the database option is copied from the options table
- * accross to the sitemeta table when WordPress is manually upgraded from
+ * accross to the sitemeta table when WordPress is upgraded from
  * a single site install to a multisite install.
  */
 function maybe_populate_site_option() {
-	if ( is_multisite() || ! defined( 'WP_ALLOW_MULTISITE') || ! WP_ALLOW_MULTISITE ) {
+	if ( is_multisite() ) {
 		return;
 	}
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -114,7 +114,7 @@ function create_tables() {
 	 *
 	 * Note: This does not work for multisite manual installs.
 	 */
-	add_filter( 'populate_network_meta', function( $site_meta ) {
+	add_filter( 'populate_network_meta', function ( $site_meta ) {
 		$site_meta['cavalcade_db_version'] = DATABASE_VERSION;
 		return $site_meta;
 	} );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -107,7 +107,8 @@ function create_tables() {
 
 	wp_cache_set( 'installed', true, 'cavalcade' );
 	update_site_option( 'cavalcade_db_version', DATABASE_VERSION );
-	/*
+
+	/**
 	 * Ensure site meta is populated when running the WP CLI script to
 	 * install a network. Using the CLI, WP installs a single site with
 	 * wp_install() and then upgrades it to a multiste install immediately.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -16,6 +16,7 @@ function bootstrap() {
 	}
 
 	register_cli_commands();
+	maybe_populate_site_option();
 	Connector\bootstrap();
 }
 
@@ -118,6 +119,28 @@ function create_tables() {
 		return $site_meta;
 	} );
 	return true;
+}
+
+/**
+ * Populate the Cavalcade db version when upgrading to multisite.
+ *
+ * This ensures the database option is copied from the options table
+ * accross to the sitemeta table when WordPress is manually upgraded from
+ * a single site install to a multisite install.
+ */
+function maybe_populate_site_option() {
+	if ( is_multisite() || ! defined( 'WP_ALLOW_MULTISITE') || ! WP_ALLOW_MULTISITE ) {
+		return;
+	}
+
+	$cavalcade_db_version = get_option( 'cavalcade_db_version' );
+
+	$set_site_meta = function( $site_meta ) use ( $cavalcade_db_version ) {
+		$site_meta['cavalcade_db_version'] = $cavalcade_db_version;
+		return $site_meta;
+	};
+
+	add_filter( 'populate_network_meta', $set_site_meta );
 }
 
 /**

--- a/plugin.php
+++ b/plugin.php
@@ -22,8 +22,6 @@ require __DIR__ . '/inc/connector/namespace.php';
 require __DIR__ . '/inc/upgrade/namespace.php';
 
 add_action( 'plugins_loaded',         __NAMESPACE__ . '\\bootstrap' );
-add_action( 'plugins_loaded',         __NAMESPACE__ . '\\register_cli_commands' );
-add_action( 'plugins_loaded',         __NAMESPACE__ . '\\Connector\\bootstrap' );
 
 // Register cache groups as early as possible, as some plugins may use cron functions before plugins_loaded
 if ( function_exists( 'wp_cache_add_global_groups' ) ) {


### PR DESCRIPTION
WP fires the `plugins_loaded` hook during the install process, causing the Cavalcade tables to be created before the options table exists.

Without an options table, Cavalcade is unable to store the version of the database it is using it ends up considering all sites to be using version 1 of the database schema.

This adds a check to ensure `is_blog_installed() == true` before adding the Cavalcade database tables. I'm not sure how this affects multisite so would value any feedback.

Fixes #73 