### PR TITLE
Query class

### DIFF
--- a/inc/class-query.php
+++ b/inc/class-query.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace HM\Cavalcade\Plugin;
+
+use WP_Date_Query;
+
+/**
+ * Query the Cavalcade Jobs table.
+ */
+class Query {
+	/**
+	 * SQL query clauses.
+	 *
+	 * @var array
+	 */
+	protected $sql_clauses = array(
+		'select'  => '',
+		'from'    => '',
+		'where'   => array(),
+		'groupby' => '',
+		'orderby' => '',
+		'limits'  => '',
+	);
+
+	/**
+	 * Date query container.
+	 *
+	 * @var object WP_Date_Query
+	 */
+	public $date_query = false;
+
+	/**
+	 * Query vars set by the user.
+	 *
+	 * @var array
+	 */
+	public $query_vars;
+
+	/**
+	 * Default values for query vars.
+	 *
+	 * @var array
+	 */
+	public $query_var_defaults;
+
+	/**
+	 * List of jobs located by the query.
+	 *
+	 * @var array
+	 */
+	public $jobs;
+
+	/**
+	 * The number of found jobs for the current query.
+	 *
+	 * @var int
+	 */
+	public $found_jobs = 0;
+}

--- a/inc/class-query.php
+++ b/inc/class-query.php
@@ -56,4 +56,46 @@ class Query {
 	 * @var int
 	 */
 	public $found_jobs = 0;
+
+	/**
+	 * Set up the Job query, based on the parameters passed.
+	 *
+	 * @param string|array $query {
+	 *     Optional. Array or query string of site query parameters. Default empty.
+	 *
+	 *     @type string   $fields   Fields to return, accepts `all` or `ids`. Default: `all`.
+	 *     @type int[]    $job_ids  Specific Job IDs to search for. Default: all matching jobs.
+	 *     @type int      $site_id  The site on which jobs run. Required.
+	 *                              Default current site.
+	 *     @type string   $hook     The job's hook name.
+	 *     @type array    $args     The job's arguments array. Default: [].
+	 *     @type array    $nextrun  Date query to limit jobs by. Default: future
+	 *                              jobs. See WP_Date_Query.
+	 *     @type int      $interval The frequency in seconds jobs run at.
+	 *     @type string   $schedule The named schedule on which jobs run.
+	 *     @type string[] $status   Array of statuses to search for, accepts
+	 *                              `waiting` (default), `failed`, `completed` or `running`.
+	 * }
+	 */
+	function __construct( $query = [] ) {
+		$this->query_var_defaults = [
+			'fields' => 'all',
+			'job_ids' => null,
+			'site_id' => get_current_blog_id(),
+			'hook' => null,
+			'args' => [],
+			// See WP_Date_Query
+			'nextrun' => [
+				[
+					'after' => 'now',
+					'inclusive' => false,
+				],
+			],
+			'interval' => null,
+			'schedule' => null,
+			'status' => [
+				'waiting',
+			],
+		];
+	}
 }

--- a/inc/class-query.php
+++ b/inc/class-query.php
@@ -97,5 +97,63 @@ class Query {
 				'waiting',
 			],
 		];
+
+		$this->query( $query );
+	}
+
+	/**
+	 * Set up the query for retrieving jobs.
+	 *
+	 * @param array $query Array of query parameters, see __construct().
+	 * @return array An array of Job instances or integers if fields is set to `ids`.
+	 */
+	function query( $query = [] ) {
+		$this->query_vars = wp_parse_args( $query, $this->query_var_defaults );
+		return $this->get_jobs();
+	}
+
+	/**
+	 * Gets jobs based on the query arguments.
+	 *
+	 * @return array An array of Job instances or integers if fields is set to `ids`.
+	 */
+	function get_jobs() {
+		$job_ids = $this->get_job_ids();
+
+		if ( $this->query_vars === 'ids' ) {
+			return $job_ids;
+		}
+	}
+
+	/**
+	 * Get job IDs baseed on the query arguments.
+	 *
+	 * @return array Array of Job IDs.
+	 */
+	function get_job_ids() {
+		$this->parse_query();
+	}
+
+	/**
+	 * Parse the passed query arguments with the defaults.
+	 *
+	 * @return void
+	 */
+	function parse_query() {
+		$query = &$this->query_vars;
+
+		$query['fields'] = strtolower( $query['fields'] );
+		if ( ! in_array( $query['fields'], ['ids', 'all' ], true ) ) {
+			$query['fields'] = 'all';
+		}
+
+		if ( ! empty( $query['jobs'] ) ) {
+			$query['jobs'] = array_filter( (array) $query['jobs'], 'is_int' );
+		}
+
+		$query['site_id'] = filter_var( $query['site_id'], FILTER_VALIDATE_INT );
+		if ( empty( $query['site_id' ] ) ) {
+			$query['site_id'] = $this->query_var_defaults['site_id'];
+		}
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,7 +76,11 @@ function create_tables() {
 		`schedule` varchar(255) DEFAULT NULL,
 
 		PRIMARY KEY (`id`),
-		KEY `status` (`status`)
+		KEY `status` (`status`),
+		KEY `site` (`site`),
+		KEY `hook_args` (`hook`, `args`(500)),
+		KEY `nextrun` (`nextrun`),
+		KEY `schedule` (`schedule`)
 	) ENGINE=InnoDB;\n";
 
 	// TODO: check return value

--- a/inc/upgrade/namespace.php
+++ b/inc/upgrade/namespace.php
@@ -25,6 +25,10 @@ function upgrade_database() {
 		upgrade_database_2();
 	}
 
+	if ( $database_version < 3 ) {
+		upgrade_database_3();
+	}
+
 	update_site_option( 'cavalcade_db_version', DATABASE_VERSION );
 
 	wp_cache_delete( 'jobs', 'cavalcade-jobs' );
@@ -58,4 +62,21 @@ function upgrade_database_2() {
 			$wpdb->prepare( $query, $name, $interval )
 		);
 	}
+}
+
+/**
+ * Upgrade Cavalcade database tables to version 3.
+ *
+ * Add new indexes to prepare for preflight filters.
+ */
+function upgrade_database_3() {
+	global $wpdb;
+
+	$query = "ALTER TABLE `{$wpdb->base_prefix}cavalcade_jobs`
+			  ADD INDEX `site` (`site`),
+			  ADD INDEX `hook_args` (`hook`, `args`(500)),
+			  ADD INDEX `nextrun` (`nextrun`),
+			  ADD INDEX `schedule` (`schedule`)";
+
+	$wpdb->query( $query );
 }

--- a/plugin.php
+++ b/plugin.php
@@ -14,7 +14,7 @@ namespace HM\Cavalcade\Plugin;
 use WP_CLI;
 
 const MYSQL_DATE_FORMAT = 'Y-m-d H:i:s';
-const DATABASE_VERSION = 2;
+const DATABASE_VERSION = 3;
 
 require __DIR__ . '/inc/namespace.php';
 require __DIR__ . '/inc/class-job.php';


### PR DESCRIPTION
A query class, the intent behind it is to set up persistent caching:

### Global Caches

* cavalcade-jobs: Individual jobs
	- name: `job:{$job_id}`

* cavalcade-query: Query results
	- name: `query:{$site_id}:{$query_and_last_changed_hash}`
	- name: `query:{$site_id}:last_changed`

Need to store the last changed time on a site by site basis and include that as part of the query hash.

#### Query

Constructs a Database query based on given paramaters

* Each individual query runs two DB queries:
	- The first returns the IDs for a given query and warms query cache
	- The second queries the IDs (SELECT WHERE IN), excluding those already cached, and warms each job's cache

* Key parameters
	- Fields: the fields to return ALL (Default), ID
	- Hook: Required
	- Site ID: defaults to current site ID
	- nextrun: default `>= time()` -- may be able to use `WP_Date_Query`
	- args: default `[]`
	- status: default waiting