### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
   - mysql
 install:
   - composer install
-  - composer global install phpunit/phpunit:7.1
+  - composer global require phpunit/phpunit:7.1
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
   - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
-  - vendor/bin/phpunit
+  - vendor/bin/phpunit --exclude-group cron
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 php:
-  - '7.1'
+  - '7.2'
 services:
   - mysql
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - mysql
 install:
   - composer install
-  - composer require phpunit/phpunit:7.1
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - '7.1'
+services:
+  - mysql
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ services:
   - mysql
 install:
   - composer install
-  - composer global require phpunit/phpunit:7.1
+  - composer require phpunit/phpunit:7.1
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
-  - phpunit
+  - vendor/bin/phpunit
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
   - mysql
 install:
   - composer install
+  - composer global install phpunit/phpunit:7.1
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 latest
 script:
   - phpunit

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"composer/installers": "~1.0"
 	},
 	"require-dev": {
-		"humanmade/coding-standards": "dev-master"
+		"humanmade/coding-standards": "dev-master",
+		"phpunit/phpunit": "7.1"
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,8 @@ require $test_root . '/includes/functions.php';
 
 tests_add_filter( 'muplugins_loaded', function () {
 	require dirname( __DIR__ ) . '/plugin.php';
+	// Call create tables before each run.
+	HM\Cavalcade\Plugin\create_tables();
 });
 
 require $test_root . '/includes/bootstrap.php';


### PR DESCRIPTION
An update to Travis meant we need to specify mysql under the `services` property now. This should fix the builds.