### PR TITLE
`$wpdb->get_results()` will never return false here, so we don't need to rely upon the `$found` flag that's not available in all object caches.

### DIFF
--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -362,10 +362,9 @@ class Job {
 		// Cache results.
 		$last_changed = wp_cache_get_last_changed( 'cavalcade-jobs' );
 		$query_hash = sha1( serialize( [ $sql, $sql_params ] ) ) . "::{$last_changed}";
-		$found = null;
-		$results = wp_cache_get( "jobs::{$query_hash}", 'cavalcade-jobs', true, $found );
+		$results = wp_cache_get( "jobs::{$query_hash}", 'cavalcade-jobs' );
 
-		if ( ! $found ) {
+		if ( false === $results ) {
 			$query = $wpdb->prepare( $sql, $sql_params );
 			$results = $wpdb->get_results( $query );
 			wp_cache_set( "jobs::{$query_hash}", $results, 'cavalcade-jobs' );


### PR DESCRIPTION
`$wpdb->get_results()` will never return false here, so we don't need to rely upon the `$found` flag that's not available in all object caches.

This fixes job query caching when running on a persistent cache which doesn't implement the `$found` parameter or doesn't consider in-memory caches as "found" (see https://github.com/Automattic/wp-memcached/issues/61).

I noticed a duplicate job query when updating WordPress.org with the plugin, stemming from Jetpack calling both `wp_next_scheduled()` and `wp_get_schedule()`.

Props @peterwilsoncc for confirming that `$wpdb->get_results()` always returns an array.