### PR TITLE
Incorrect pre_get_ready_cron_jobs implementation

### DIFF
--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -366,14 +366,14 @@ function pre_get_ready_cron_jobs( $pre ) {
 		$timestamp = $result->nextrun;
 		$hook = $result->hook;
 		$key = md5( serialize( $result->args ) );
-		$value = (object) [
+		$value = [
 			'schedule'  => $result->schedule,
 			'args'      => $result->args,
 			'_job'      => $result,
 		];
 
 		if ( isset( $result->interval ) ) {
-			$value->interval = (int) $result->interval;
+			$value['interval'] = (int) $result->interval;
 		}
 
 		// Build the array up.


### PR DESCRIPTION
This fixes a fatal error when something requests wp-cron.php while Cavalcade is in use:

```
Uncaught Error: Cannot use object of type stdClass as array in /public_html/wp-cron.php:121
```

It seems that Cavalcade returns an object here, where WordPress is expecting an array:
https://core.trac.wordpress.org/browser/trunk/src/wp-cron.php?marks=121#L112