### PR TITLE
Eager bootstrapping of the plugin

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -143,10 +143,8 @@ function maybe_populate_site_option() {
 		return;
 	}
 
-	$cavalcade_db_version = get_option( 'cavalcade_db_version' );
-
-	$set_site_meta = function ( $site_meta ) use ( $cavalcade_db_version ) {
-		$site_meta['cavalcade_db_version'] = $cavalcade_db_version;
+	$set_site_meta = function ( $site_meta ) {
+		$site_meta['cavalcade_db_version'] = get_option( 'cavalcade_db_version' );
 		return $site_meta;
 	};
 

--- a/plugin.php
+++ b/plugin.php
@@ -19,7 +19,7 @@ require __DIR__ . '/inc/class-job.php';
 require __DIR__ . '/inc/connector/namespace.php';
 require __DIR__ . '/inc/upgrade/namespace.php';
 
-add_action( 'plugins_loaded', __NAMESPACE__ . '\\bootstrap' );
+bootstrap();
 
 // Register cache groups as early as possible, as some plugins may use cron functions before plugins_loaded
 if ( function_exists( 'wp_cache_add_global_groups' ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,6 +2,8 @@
 /**
  * Bootstrap the plugin unit testing environment.
  *
+ * phpcs:disable PSR1.Files.SideEffects
+ *
  * @package WordPress
 */
 


### PR DESCRIPTION
We can't know for sure how the plugin is loaded, eg. as a muplugin or otherwise but we can at least bootstrap it as soon as the file is loaded. This means any plugins such as Jetpack doing odd things on plugins loaded like scheduling events will be using Cavalcade instead of the options table.

Fixes #83 kind of