### PR TITLE
Reduce number of DB queries

### DIFF
--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * phpcs:ignoreFile WordPress.DB.PreparedSQL.NotPrepared
+ * phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
  */
 
 namespace HM\Cavalcade\Plugin;

--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -353,15 +353,16 @@ class Job {
 
 			// Timestamp array range.
 			if ( is_array( $args['timestamp'] ) && count( $args['timestamp'] ) === 2 ) {
+				// SQL BETWEEN is inclusive of start and end values.
 				return (
-					$event->nextrun > date( DATE_FORMAT, (int) $args['timestamp'][0] )
+					$event->nextrun >= date( DATE_FORMAT, (int) $args['timestamp'][0] )
 					&& $event->nextrun <= date( DATE_FORMAT, (int) $args['timestamp'][1] )
 				);
 			}
 
 			// Default integer timestamp.
 			if ( is_int( $args['timestamp'] ) ) {
-				return $event->timestamp === date( DATE_FORMAT, (int) $args['timestamp'] );
+				return $event->nextrun === date( DATE_FORMAT, (int) $args['timestamp'] );
 			}
 
 			return true;

--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -333,35 +333,35 @@ class Job {
 
 		// Filter results array.
 		$results = array_filter( $results, function ( $event ) use ( $args ) : bool {
-			if ( is_string( $args['hook'] ) && $event['hook'] !== $args['hook'] ) {
+			if ( is_string( $args['hook'] ) && $event->hook !== $args['hook'] ) {
 				return false;
 			}
 
-			if ( ! is_null( $args['args'] ) && $event['args'] !== serialize( $args['args'] ) ) {
+			if ( ! is_null( $args['args'] ) && $event->args !== serialize( $args['args'] ) ) {
 				return false;
 			}
 
 			// Timestamp 'future' shortcut.
 			if ( $args['timestamp'] === 'future' ) {
-				return $event['nextrun'] > date( DATE_FORMAT );
+				return $event->nextrun > date( DATE_FORMAT );
 			}
 
 			// Timestamp past shortcut.
 			if ( $args['timestamp'] === 'past' ) {
-				return $event['nextrun'] <= date( DATE_FORMAT );
+				return $event->nextrun <= date( DATE_FORMAT );
 			}
 
 			// Timestamp array range.
 			if ( is_array( $args['timestamp'] ) && count( $args['timestamp'] ) === 2 ) {
 				return (
-					$event['nextrun'] > date( DATE_FORMAT, (int) $args['timestamp'][0] )
-					&& $event['nextrun'] <= date( DATE_FORMAT, (int) $args['timestamp'][1] )
+					$event->nextrun > date( DATE_FORMAT, (int) $args['timestamp'][0] )
+					&& $event->nextrun <= date( DATE_FORMAT, (int) $args['timestamp'][1] )
 				);
 			}
 
 			// Default integer timestamp.
 			if ( is_int( $args['timestamp'] ) ) {
-				return 'timestamp' === date( DATE_FORMAT, (int) $args['timestamp'] );
+				return $event->timestamp === date( DATE_FORMAT, (int) $args['timestamp'] );
 			}
 
 			return true;

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -384,7 +384,7 @@ function pre_get_scheduled_event( $pre, $hook, $args, $timestamp ) {
 	$jobs = Job::get_jobs_by_query( [
 		'args' => null,
 		'hook' => null,
-		'limit' => 500, // High bounded limit, should be enough to get all upcoming jobs.
+		'limit' => 100,
 	] );
 
 	$filter = [


### PR DESCRIPTION
Fixes #117

The DB query fetches pretty much everything, just varying on statuses and site ID which won't change unless someone needs to query the jobs directly.

The resulting array is then filtered in PHP instead so the trade off is an 0(n) process in PHP rather than additional requests to the db each time `wp_next_scheduled()` is called.