### PR TITLE
Add support for returning `WP_Error` objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+tests/tests/class-wp-core-cron.php
+.phpunit.result.cache
+composer.lock
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: php
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 env:
   - WP_VERSION=latest WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
 matrix:
   include:
-    - php: 7.3
+    - php: 7.4
       env: WP_VERSION=trunk WP_MULTISITE=0
-    - php: 7.3
+    - php: 7.4
       env: WP_VERSION=trunk WP_MULTISITE=1
+allow_failures:
+  - php: 8.0
 services:
   - mysql
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: php
 php:
-  - 7.3
   - 7.4
   - 8.0
+  - 8.1
 env:
   - WP_VERSION=latest WP_MULTISITE=0
   - WP_VERSION=latest WP_MULTISITE=1
 matrix:
   include:
-    - php: 7.4
+    - php: 8.0
       env: WP_VERSION=trunk WP_MULTISITE=0
-    - php: 7.4
+    - php: 8.0
       env: WP_VERSION=trunk WP_MULTISITE=1
 allow_failures:
-  - php: 8.0
+  - php: 8.1
 services:
   - mysql
 install:
   - composer install
   - bash tests/install-tests.sh wordpress_test root '' 127.0.0.1 $WP_VERSION
 script:
-  # 32656 tests are related to the pre_*_event filters which we're using already
-  - vendor/bin/phpunit --exclude-group 32656
+  - vendor/bin/phpunit
 notifications:
     email: false

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,12 @@
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {
-		"humanmade/coding-standards": "dev-master",
-		"phpunit/phpunit": "^7.1",
+		"phpunit/phpunit": "^7.1 || ^9.0",
 		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"config": {
 		"allow-plugins": {
-			"composer/installers": true,
-			"dealerdirect/phpcodesniffer-composer-installer": true
+			"composer/installers": true
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 	},
 	"require-dev": {
 		"humanmade/coding-standards": "dev-master",
-		"phpunit/phpunit": "^7.1"
+		"phpunit/phpunit": "^7.1",
+		"yoast/phpunit-polyfills": "^1.0"
 	},
 	"config": {
 		"allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -11,10 +11,16 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0"
+		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {
 		"humanmade/coding-standards": "dev-master",
-		"phpunit/phpunit": "7.1"
+		"phpunit/phpunit": "^7.1"
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/inc/class-job.php
+++ b/inc/class-job.php
@@ -70,6 +70,7 @@ class Job {
 
 		self::flush_query_cache();
 		wp_cache_set( "job::{$this->id}", $this, 'cavalcade-jobs' );
+		return (bool) $result;
 	}
 
 	public function delete( $options = [] ) {

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -195,8 +195,8 @@ function pre_reschedule_event( $pre, $event, $wp_error = false ) {
 		if ( $wp_error ) {
 			if ( ! is_wp_error( $jobs ) ) {
 				$jobs = new WP_Error(
-					'schedule_event_false',
-					__( 'A plugin disallowed this event.' )
+					'invalid_event',
+					__( 'Event does not exist.', 'cavalcade' )
 				);
 			}
 			return $jobs;
@@ -258,7 +258,7 @@ function pre_unschedule_event( $pre, $timestamp, $hook, $args, $wp_error = false
 			if ( ! is_wp_error( $jobs ) ) {
 				$jobs = new WP_Error(
 					'invalid_event',
-					__( 'Event does not exist.' )
+					__( 'Event does not exist.', 'cavalcade' )
 				);
 			}
 			return $jobs;

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -29,7 +29,7 @@ function bootstrap() {
 /**
  * Schedule an event with Cavalcade.
  *
- * @param null|bool $pre Value to return instead. Default null to continue adding the event.
+ * @param null|bool|WP_Error $pre Value to return instead. Default null to continue adding the event.
  * @param stdClass $event {
  *     An object containing an event's data.
  *
@@ -40,7 +40,7 @@ function bootstrap() {
  *     @type int          $interval  The interval time in seconds for the schedule. Only present for recurring events.
  * }
  * @param bool $wp_error If true returns a WP_Error instead of false.
- * @return null|bool|WP_Error True if event successfully scheduled. False for failure.
+ * @return null|bool|WP_Error True if event successfully scheduled. False or WP_Error for failure.
  */
 function pre_schedule_event( $pre, $event, $wp_error = false ) {
 	// Allow other filters to do their thing.
@@ -151,7 +151,7 @@ function pre_schedule_event( $pre, $event, $wp_error = false ) {
  * To ensure the next run time is in the future, it is recommended you delete and reschedule
  * a job.
  *
- * @param null|bool $pre   Value to return instead. Default null to continue adding the event.
+ * @param null|bool|WP_Error $pre Value to return instead. Default null to continue adding the event.
  * @param stdClass  $event {
  *     An object containing an event's data.
  *
@@ -162,7 +162,7 @@ function pre_schedule_event( $pre, $event, $wp_error = false ) {
  *     @type int          $interval  The interval time in seconds for the schedule. Only present for recurring events.
  * }
  * @param bool $wp_error Optional. Whether to return a WP_Error on failure. Default false.
- * @return bool True if event successfully rescheduled. False for failure.
+ * @return bool|WP_Error True if event successfully rescheduled. False or WP_Error for failure.
  */
 function pre_reschedule_event( $pre, $event, $wp_error = false ) {
 	// Allow other filters to do their thing.
@@ -232,12 +232,12 @@ function pre_reschedule_event( $pre, $event, $wp_error = false ) {
  * The $timestamp and $hook parameters are required so that the event can be
  * identified.
  *
- * @param null|bool $pre       Value to return instead. Default null to continue unscheduling the event.
+ * @param null|bool|WP_Error $pre Value to return instead. Default null to continue unscheduling the event.
  * @param int       $timestamp Timestamp for when to run the event.
  * @param string    $hook      Action hook, the execution of which will be unscheduled.
  * @param array     $args      Arguments to pass to the hook's callback function.
  * @param bool $wp_error Optional. Whether to return a WP_Error on failure. Default false.
- * @return null|bool True if event successfully unscheduled. False for failure.
+ * @return null|bool|WP_Error True if event successfully unscheduled. False or WP_Error for failure.
  */
 function pre_unschedule_event( $pre, $timestamp, $hook, $args, $wp_error = false ) {
 	// Allow other filters to do their thing.
@@ -282,13 +282,13 @@ function pre_unschedule_event( $pre, $timestamp, $hook, $args, $wp_error = false
  * {@link https://php.net/manual/en/language.types.boolean.php PHP documentation}. Use
  * the `===` operator for testing the return value of this function.
  *
- * @param null|array $pre  Value to return instead. Default null to continue unscheduling the event.
+ * @param null|array|WP_Error $pre Value to return instead. Default null to continue unscheduling the event.
  * @param string     $hook Action hook, the execution of which will be unscheduled.
  * @param array|null $args Arguments to pass to the hook's callback function, null to clear all
  *                         events regardless of arugments.
  * @param bool $wp_error Optional. Whether to return a WP_Error on failure. Default false.
- * @return bool|int  On success an integer indicating number of events unscheduled (0 indicates no
- *                   events were registered with the hook and arguments combination), false if
+ * @return bool|int|WP_Error On success an integer indicating number of events unscheduled (0 indicates no
+ *                   events were registered with the hook and arguments combination), false or WP_Error if
  *                   unscheduling one or more events fail.
 */
 function pre_clear_scheduled_hook( $pre, $hook, $args, $wp_error = false ) {
@@ -351,11 +351,11 @@ function pre_clear_scheduled_hook( $pre, $hook, $args, $wp_error = false ) {
  * {@link https://php.net/manual/en/language.types.boolean.php PHP documentation}. Use
  * the `===` operator for testing the return value of this function.
  *
- * @param null|array $pre  Value to return instead. Default null to continue unscheduling the hook.
+ * @param null|array|WP_Error $pre Value to return instead. Default null to continue unscheduling the hook.
  * @param string     $hook Action hook, the execution of which will be unscheduled.
  * @param bool $wp_error Optional. Whether to return a WP_Error on failure. Default false.
- * @return bool|int On success an integer indicating number of events unscheduled (0 indicates no
- *                  events were registered on the hook), false if unscheduling fails.
+ * @return bool|int|WP_Error On success an integer indicating number of events unscheduled (0 indicates no
+ *                  events were registered on the hook), false or WP_Error if unscheduling fails.
  */
 function pre_unschedule_hook( $pre, $hook, $wp_error = false ) {
 	return pre_clear_scheduled_hook( $pre, $hook, null, $wp_error );
@@ -474,7 +474,7 @@ function pre_get_ready_cron_jobs( $pre ) {
  *     @param int|null $interval Time in seconds between events (derived from `$schedule` value)
  * }
  * @param bool $wp_error Optional. Whether to return a WP_Error on failure. Default false.
- * @return stdClass Event object passed in (as we aren't hijacking it)
+ * @return bool|stdClass|WP_Error Event object passed in (as we aren't hijacking it). False or WP_Error if job not saved.
  */
 function schedule_event( $event, $wp_error = false ) {
 	// Make sure timestamp is a positive integer.

--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -121,8 +121,8 @@ function pre_schedule_event( $pre, $event, $wp_error = false ) {
 		// Unchanged recurring event.
 		if ( $wp_error ) {
 			return new WP_Error(
-				'unchanged_recurring_event',
-				__( 'A recurring event already exists.' )
+				'duplicate_event',
+				__( 'A duplicate event already exists.' )
 			);
 		}
 		return false;

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,17 +7,16 @@
 	convertWarningsToExceptions="true"
 	>
 	<testsuites>
-		<testsuite>
-			<directory prefix="class-" suffix=".php">tests</directory>
+		<testsuite name="cavalcade">
+			<directory prefix="class-" suffix=".php">tests/tests</directory>
 		</testsuite>
 	</testsuites>
-	<filter>
-		<blacklist>
-			<directory suffix=".php">.</directory>
-		</blacklist>
-		<whitelist>
-			<directory suffix=".php">./inc</directory>
-			<file>./plugin.php</file>
-		</whitelist>
-	</filter>
+	<groups>
+		<exclude>
+			<group>32656</group>
+			<group>49961</group>
+			<group>53635</group>
+			<group>53950</group>
+		</exclude>
+	</groups>
 </phpunit>

--- a/tests/install-tests.sh
+++ b/tests/install-tests.sh
@@ -126,11 +126,11 @@ install_db() {
 # tests for Cavalcade to ensure the plugin does
 # not change the behaviour.
 install_core_cron_tests() {
-	download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/tests/cron.php "$TRAVIS_BUILD_DIR"/tests/class-wp-core-cron.php
+	download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/tests/cron.php "$TRAVIS_BUILD_DIR"/tests/tests/class-wp-core-cron.php
 }
 
 
 install_wp
 install_test_suite
-install_db
 install_core_cron_tests
+install_db

--- a/tests/tests/class-tests-rescheduling.php
+++ b/tests/tests/class-tests-rescheduling.php
@@ -9,16 +9,16 @@ use WP_UnitTestCase;
  * @ticket 64
  */
 class Tests_Rescheduling extends WP_UnitTestCase {
-	function setUp() {
-		parent::setUp();
+	function set_up() {
+		parent::set_up();
 		// make sure the schedule is clear
 		_set_cron_array( [] );
 	}
 
-	function tearDown() {
+	function tear_down() {
 		// make sure the schedule is clear
 		_set_cron_array( [] );
-		parent::tearDown();
+		parent::tear_down();
 	}
 
 	function test_recheduling() {


### PR DESCRIPTION
Builds are currently not running or broken.

Required updating for the latest version of WP - allowing for returning `WP_Error` objects as well as the latest WP test framework.

I had to remove PHPCS as a dependency because it's currently not compatible with PHPUnit 9, it's handled separately via linter bot anyway.

Fixes #108 