### PR TITLE
Check to see if the job has been running more then 3 hours

### DIFF
--- a/inc/connector/namespace.php
+++ b/inc/connector/namespace.php
@@ -268,8 +268,14 @@ function pre_unschedule_event( $pre, $timestamp, $hook, $args, $wp_error = false
 
 	$job = $jobs[0];
 
-	// Delete it.
-	$job->delete();
+	// Check if the job is running more then 3 hours from the timestamp.
+	$is_delete_running = ( time() - $job->start ) > 10800;
+	if ( $is_delete_running ) {
+		$job->delete( [ 'delete_running' => $is_delete_running ] );
+	} else {
+		// Delete it.
+		$job->delete();
+	}
 
 	return true;
 }


### PR DESCRIPTION
When a job is stuck (long running jobs) it makes it hard to delete the job when using plugins like WP Crontrol. 

This PR is based on a solution that has been tested and is being used on an existing project that allows for us to delete these jobs via WP Control.

Props: @ivankristianto 